### PR TITLE
hackathon_detial.json 파일 단일 리스트구조로 변경, 데이터 추가 

### DIFF
--- a/src/data/public_hackathon_detail.json
+++ b/src/data/public_hackathon_detail.json
@@ -1,200 +1,280 @@
-{
-  "slug": "aimers-8-model-lite",
-  "title": "Aimers 8기 : 모델 경량화 온라인 해커톤",
-  "sections": {
-    "overview": {
-      "summary": "제한된 평가 환경에서 모델의 성능과 추론 속도를 함께 최적화합니다.",
-      "teamPolicy": {
-        "allowSolo": true,
-        "maxTeamSize": 5
-      }
-    },
-    "info": {
-      "notice": [
-        "제출 마감 이후 추가 제출은 불가합니다.",
-        "평가 환경은 고정이며, 제출물은 별도 설치 없이 실행 가능해야 합니다."
-      ],
-      "links": {
-        "rules": "https://example.com/public/rules/aimers8",
-        "faq": "https://example.com/public/faq/aimers8"
-      }
-    },
-    "eval": {
-      "metricName": "FinalScore",
-      "description": "성능과 속도를 종합한 점수(세부 산식은 규정 참고).",
-      "limits": {
-        "maxRuntimeSec": 1200,
-        "maxSubmissionsPerDay": 5
-      }
-    },
-    "schedule": {
-      "timezone": "Asia/Seoul",
-      "milestones": [
-        {
-          "name": "리더보드 제출 마감",
-          "at": "2026-02-25T10:00:00+09:00"
-        },
-        {
-          "name": "대회 종료",
-          "at": "2026-02-26T10:00:00+09:00"
+[
+  {
+    "slug": "aimers-8-model-lite",
+    "title": "Aimers 8기 : 모델 경량화 온라인 해커톤",
+    "sections": {
+      "overview": {
+        "summary": "제한된 평가 환경에서 모델의 성능과 추론 속도를 함께 최적화합니다.",
+        "teamPolicy": {
+          "allowSolo": true,
+          "maxTeamSize": 5
         }
-      ]
-    },
-    "prize": {
-      "items": [
-        {
-          "place": "1st",
-          "amountKRW": 3000000
-        },
-        {
-          "place": "2nd",
-          "amountKRW": 1500000
-        },
-        {
-          "place": "3rd",
-          "amountKRW": 800000
+      },
+      "info": {
+        "notice": [
+          "제출 마감 이후 추가 제출은 불가합니다.",
+          "평가 환경은 고정이며, 제출물은 별도 설치 없이 실행 가능해야 합니다."
+        ],
+        "links": {
+          "rules": "https://example.com/public/rules/aimers8",
+          "faq": "https://example.com/public/faq/aimers8"
         }
-      ]
-    },
-    "teams": {
-      "campEnabled": true,
-      "listUrl": "/camp?hackathon=aimers-8-model-lite"
-    },
-    "submit": {
-      "allowedArtifactTypes": [
-        "zip"
-      ],
-      "submissionUrl": "/hackathons/aimers-8-model-lite#submit",
-      "guide": [
-        "제출물은 규정에 맞는 단일 zip 파일로 업로드합니다.",
-        "업로드 후 '제출' 버튼을 눌러야 리더보드에 반영됩니다."
-      ]
-    },
-    "leaderboard": {
-      "publicLeaderboardUrl": "/hackathons/aimers-8-model-lite#leaderboard",
-      "note": "Public 리더보드는 제출 마감 시점 기준으로 고정될 수 있습니다(규정 참고)."
+      },
+      "eval": {
+        "metricName": "FinalScore",
+        "description": "성능과 속도를 종합한 점수(세부 산식은 규정 참고).",
+        "limits": {
+          "maxRuntimeSec": 1200,
+          "maxSubmissionsPerDay": 5
+        }
+      },
+      "schedule": {
+        "timezone": "Asia/Seoul",
+        "milestones": [
+          {
+            "name": "리더보드 제출 마감",
+            "at": "2026-02-25T10:00:00+09:00"
+          },
+          {
+            "name": "대회 종료",
+            "at": "2026-02-26T10:00:00+09:00"
+          }
+        ]
+      },
+      "prize": {
+        "items": [
+          {
+            "place": "1st",
+            "amountKRW": 3000000
+          },
+          {
+            "place": "2nd",
+            "amountKRW": 1500000
+          },
+          {
+            "place": "3rd",
+            "amountKRW": 800000
+          }
+        ]
+      },
+      "teams": {
+        "campEnabled": true,
+        "listUrl": "/camp?hackathon=aimers-8-model-lite"
+      },
+      "submit": {
+        "allowedArtifactTypes": [
+          "zip"
+        ],
+        "submissionUrl": "/hackathons/aimers-8-model-lite#submit",
+        "guide": [
+          "제출물은 규정에 맞는 단일 zip 파일로 업로드합니다.",
+          "업로드 후 '제출' 버튼을 눌러야 리더보드에 반영됩니다."
+        ]
+      },
+      "leaderboard": {
+        "publicLeaderboardUrl": "/hackathons/aimers-8-model-lite#leaderboard",
+        "note": "Public 리더보드는 제출 마감 시점 기준으로 고정될 수 있습니다(규정 참고)."
+      }
     }
   },
-  "extraDetails": [
-    {
-      "slug": "daker-handover-2026-03",
-      "title": "긴급 인수인계 해커톤: 명세서만 보고 구현하라",
-      "sections": {
-        "overview": {
-          "summary": "기능 명세서만 남기고 사라진 개발자의 문서를 기반으로 바이브 코딩을 통해 웹서비스를 구현·배포하는 해커톤입니다.",
-          "teamPolicy": {
-            "allowSolo": true,
-            "maxTeamSize": 5
-          }
-        },
-        "info": {
-          "notice": [
-            "예시 자료 외 데이터는 제공되지 않습니다.",
-            "더미 데이터/로컬 저장소(localStorage 등)를 활용해 구현하세요.",
-            "배포 URL은 외부에서 접속 가능해야하며 심사 기간동안 접근 가능해야합니다.",
-            "외부 API/외부 DB를 쓰는 경우에도 심사자가 별도 키 없이 확인 가능해야 합니다. (키가 필요한 기능은 평가에서 확인이 제한될 수 있음)"
-          ],
-          "links": {
-            "rules": "https://example.com/public/rules/daker-handover-202603",
-            "faq": "https://example.com/public/faq/daker-handover-202603"
-          }
-        },
-        "eval": {
-          "metricName": "FinalScore",
-          "description": "참가팀/심사위원 투표 점수를 가중치로 합산한 최종 점수",
-          "scoreSource": "vote",
-          "scoreDisplay": {
-            "label": "투표 점수",
-            "breakdown": [
-              {
-                "key": "participant",
-                "label": "참가자",
-                "weightPercent": 30
-              },
-              {
-                "key": "judge",
-                "label": "심사위원",
-                "weightPercent": 70
-              }
-            ]
-          }
-        },
-        "schedule": {
-          "timezone": "Asia/Seoul",
-          "milestones": [
-            {
-              "name": "접수/기획서 제출 기간",
-              "at": "2026-03-04T10:00:00+09:00"
-            },
-            {
-              "name": "접수/기획서 제출 마감",
-              "at": "2026-03-30T10:00:00+09:00"
-            },
-            {
-              "name": "최종 웹링크 제출 마감",
-              "at": "2026-04-06T10:00:00+09:00"
-            },
-            {
-              "name": "최종 솔루션 PDF 제출 마감",
-              "at": "2026-04-13T10:00:00+09:00"
-            },
-            {
-              "name": "1차 투표평가 시작",
-              "at": "2026-04-13T12:00:00+09:00"
-            },
-            {
-              "name": "1차 투표평가 마감",
-              "at": "2026-04-17T10:00:00+09:00"
-            },
-            {
-              "name": "2차 내부평가 종료",
-              "at": "2026-04-24T23:59:00+09:00"
-            },
-            {
-              "name": "최종 결과 발표",
-              "at": "2026-04-27T10:00:00+09:00"
-            }
-          ]
-        },
-        "teams": {
-          "campEnabled": true,
-          "listUrl": "/camp?hackathon=daker-handover-2026-03"
-        },
-        "submit": {
-          "allowedArtifactTypes": [
-            "text",
-            "url",
-            "pdf"
-          ],
-          "submissionUrl": "/hackathons/daker-handover-2026-03#submit",
-          "guide": [
-            "기획서 → 웹링크 → PDF를 단계별로 제출합니다.",
-            "배포 URL은 외부에서 접속 가능해야 하며 심사 기간 동안 접근 가능해야 합니다.",
-            "PPT는 PDF로 변환하여 제출합니다."
-          ],
-          "submissionItems": [
-            {
-              "key": "plan",
-              "title": "기획서(1차 제출)",
-              "format": "text_or_url"
-            },
-            {
-              "key": "web",
-              "title": "최종 웹링크 제출",
-              "format": "url"
-            },
-            {
-              "key": "pdf",
-              "title": "최종 솔루션 PDF 제출",
-              "format": "pdf_url"
-            }
-          ]
-        },
-        "leaderboard": {
-          "publicLeaderboardUrl": "/hackathons/daker-handover-2026-03#leaderboard",
-          "note": "아이디어 해커톤의 점수(score)는 투표 결과를 기반으로 표시됩니다."
+  {
+    "slug": "monthly-vibe-coding-2026-02",
+    "title": "월간 해커톤 : 바이브 코딩 개선 AI 아이디어 공모전 (2026.02)",
+    "sections": {
+      "overview": {
+        "summary": "AI 기반 바이브 코딩 워크플로우를 개선하는 아이디어 해커톤입니다.",
+        "teamPolicy": {
+          "allowSolo": true,
+          "maxTeamSize": 5
         }
+      },
+      "info": {
+        "notice": [
+          "아이디어 중심 평가입니다.",
+          "제출 이후 수정 불가"
+        ],
+        "links": {
+          "rules": "https://example.com/public/rules/vibe202602",
+          "faq": "https://example.com/public/faq/vibe202602"
+        }
+      },
+      "eval": {
+        "metricName": "FinalScore",
+        "description": "투표 기반 점수",
+        "scoreSource": "vote",
+        "scoreDisplay": {
+          "breakdown": [
+            {
+              "key": "participant",
+              "weightPercent": 40
+            },
+            {
+              "key": "judge",
+              "weightPercent": 60
+            }
+          ]
+        }
+      },
+      "schedule": {
+        "timezone": "Asia/Seoul",
+        "milestones": [
+          {
+            "name": "제출 시작",
+            "at": "2026-02-10T10:00:00+09:00"
+          },
+          {
+            "name": "제출 마감",
+            "at": "2026-03-03T10:00:00+09:00"
+          },
+          {
+            "name": "결과 발표",
+            "at": "2026-03-09T10:00:00+09:00"
+          }
+        ]
+      },
+      "prize": {
+        "items": [
+          { "place": "1st", "amountKRW": 1000000 },
+          { "place": "2nd", "amountKRW": 500000 },
+          { "place": "3rd", "amountKRW": 300000 }
+        ]
+      },
+      "teams": {
+        "campEnabled": true,
+        "listUrl": "/camp?hackathon=monthly-vibe-coding-2026-02"
+      },
+      "submit": {
+        "allowedArtifactTypes": ["text", "url"],
+        "submissionUrl": "/hackathons/monthly-vibe-coding-2026-02#submit",
+        "guide": [
+          "아이디어를 텍스트 또는 URL로 제출",
+          "제출 버튼을 눌러야 반영됨"
+        ]
+      },
+      "leaderboard": {
+        "publicLeaderboardUrl": "/hackathons/monthly-vibe-coding-2026-02#leaderboard",
+        "note": "투표 기반 리더보드"
       }
     }
-  ]
-}
+  },
+  {
+    "slug": "daker-handover-2026-03",
+    "title": "긴급 인수인계 해커톤: 명세서만 보고 구현하라",
+    "sections": {
+      "overview": {
+        "summary": "기능 명세서만 남기고 사라진 개발자의 문서를 기반으로 바이브 코딩을 통해 웹서비스를 구현·배포하는 해커톤입니다.",
+        "teamPolicy": {
+          "allowSolo": true,
+          "maxTeamSize": 5
+        }
+      },
+      "info": {
+        "notice": [
+          "예시 자료 외 데이터는 제공되지 않습니다.",
+          "더미 데이터/로컬 저장소(localStorage 등)를 활용해 구현하세요.",
+          "배포 URL은 외부에서 접속 가능해야하며 심사 기간동안 접근 가능해야합니다.",
+          "외부 API/외부 DB를 쓰는 경우에도 심사자가 별도 키 없이 확인 가능해야 합니다. (키가 필요한 기능은 평가에서 확인이 제한될 수 있음)"
+        ],
+        "links": {
+          "rules": "https://example.com/public/rules/daker-handover-202603",
+          "faq": "https://example.com/public/faq/daker-handover-202603"
+        }
+      },
+      "eval": {
+        "metricName": "FinalScore",
+        "description": "참가팀/심사위원 투표 점수를 가중치로 합산한 최종 점수",
+        "scoreSource": "vote",
+        "scoreDisplay": {
+          "label": "투표 점수",
+          "breakdown": [
+            {
+              "key": "participant",
+              "label": "참가자",
+              "weightPercent": 30
+            },
+            {
+              "key": "judge",
+              "label": "심사위원",
+              "weightPercent": 70
+            }
+          ]
+        }
+      },
+      "schedule": {
+        "timezone": "Asia/Seoul",
+        "milestones": [
+          {
+            "name": "접수/기획서 제출 기간",
+            "at": "2026-03-04T10:00:00+09:00"
+          },
+          {
+            "name": "접수/기획서 제출 마감",
+            "at": "2026-03-30T10:00:00+09:00"
+          },
+          {
+            "name": "최종 웹링크 제출 마감",
+            "at": "2026-04-06T10:00:00+09:00"
+          },
+          {
+            "name": "최종 솔루션 PDF 제출 마감",
+            "at": "2026-04-13T10:00:00+09:00"
+          },
+          {
+            "name": "1차 투표평가 시작",
+            "at": "2026-04-13T12:00:00+09:00"
+          },
+          {
+            "name": "1차 투표평가 마감",
+            "at": "2026-04-17T10:00:00+09:00"
+          },
+          {
+            "name": "2차 내부평가 종료",
+            "at": "2026-04-24T23:59:00+09:00"
+          },
+          {
+            "name": "최종 결과 발표",
+            "at": "2026-04-27T10:00:00+09:00"
+          }
+        ]
+      },
+      "teams": {
+        "campEnabled": true,
+        "listUrl": "/camp?hackathon=daker-handover-2026-03"
+      },
+      "submit": {
+        "allowedArtifactTypes": [
+          "text",
+          "url",
+          "pdf"
+        ],
+        "submissionUrl": "/hackathons/daker-handover-2026-03#submit",
+        "guide": [
+          "기획서 → 웹링크 → PDF를 단계별로 제출합니다.",
+          "배포 URL은 외부에서 접속 가능해야 하며 심사 기간 동안 접근 가능해야 합니다.",
+          "PPT는 PDF로 변환하여 제출합니다."
+        ],
+        "submissionItems": [
+          {
+            "key": "plan",
+            "title": "기획서(1차 제출)",
+            "format": "text_or_url"
+          },
+          {
+            "key": "web",
+            "title": "최종 웹링크 제출",
+            "format": "url"
+          },
+          {
+            "key": "pdf",
+            "title": "최종 솔루션 PDF 제출",
+            "format": "pdf_url"
+          }
+        ]
+      },
+      "leaderboard": {
+        "publicLeaderboardUrl": "/hackathons/daker-handover-2026-03#leaderboard",
+        "note": "아이디어 해커톤의 점수(score)는 투표 결과를 기반으로 표시됩니다."
+      }
+    }
+  }
+]

--- a/src/features/Eval.tsx
+++ b/src/features/Eval.tsx
@@ -33,12 +33,8 @@ type HackathonDetailItem = {
 }
 
 function getEvalSectionBySlug(slug: string): EvalSection | null {
-  const root = hackathonDetailData as HackathonDetailItem & {
-    extraDetails?: HackathonDetailItem[]
-  }
-
-  if (root.slug === slug) return root.sections?.eval ?? null
-  const detail = root.extraDetails?.find((item) => item.slug === slug)
+  const details = hackathonDetailData as HackathonDetailItem[]
+  const detail = details.find((item) => item.slug === slug)
   return detail?.sections?.eval ?? null
 }
 

--- a/src/features/Leaderboard.tsx
+++ b/src/features/Leaderboard.tsx
@@ -112,11 +112,8 @@ function getSubmissionsFromStorage(): Submission[] {
 }
 
 function getEvalSectionBySlug(slug: string): EvalSection | null {
-  const root = hackathonDetailData as HackathonDetailItem & {
-    extraDetails?: HackathonDetailItem[]
-  }
-  if (root.slug === slug) return root.sections?.eval ?? null
-  const detail = root.extraDetails?.find((item) => item.slug === slug)
+  const details = hackathonDetailData as HackathonDetailItem[]
+  const detail = details.find((item) => item.slug === slug)
   return detail?.sections?.eval ?? null
 }
 

--- a/src/features/Submit.tsx
+++ b/src/features/Submit.tsx
@@ -42,12 +42,8 @@ type TeamOption = {
 }
 
 function getSubmitSectionBySlug(slug: string): SubmitSection | null {
-  const root = hackathonDetailData as HackathonDetailItem & {
-    extraDetails?: HackathonDetailItem[]
-  }
-
-  if (root.slug === slug) return root.sections?.submit ?? null
-  const detail = root.extraDetails?.find((item) => item.slug === slug)
+  const details = hackathonDetailData as HackathonDetailItem[]
+  const detail = details.find((item) => item.slug === slug)
   return detail?.sections?.submit ?? null
 }
 


### PR DESCRIPTION
  변경 사항:

  1. public_hackathon_detail.json을 단일 리스트(배열) 구조로 변경
  2. 디테일에 없던 monthly-vibe-coding-2026-02 데이터 추가
  3. 새 구조에 맞게 slug 조회 로직 수정

  - src/data/public_hackathon_detail.json
  - src/features/Eval.tsx
  - src/features/Submit.tsx
  - src/features/Leaderboard.tsx

  - extraDetails 참조는 코드에서 모두 제거됨