### PR TITLE
팀 관리 및 초대 시스템 구축

### DIFF
--- a/src/api/teamApi.ts
+++ b/src/api/teamApi.ts
@@ -1,7 +1,8 @@
-import type { Team } from "../types/team"
+import type { Team, TeamInvite, InviteStatus, TeamMember } from "../types/team"
 import publicTeams from "../data/public_teams.json"
 
 const LOCAL_STORAGE_KEY = "teams"
+const INVITES_STORAGE_KEY = "team_invites"
 
 const getStoredTeams = (): Team[] => {
   const stored = localStorage.getItem(LOCAL_STORAGE_KEY)
@@ -10,10 +11,15 @@ const getStoredTeams = (): Team[] => {
   }
   
   // 초기 데이터가 없는 경우 public_teams.json에서 가져오기
-  // authorId가 없는 초기 데이터들에 대해 기본값 '1'(Alice) 부여
   const initialTeams = (publicTeams as any[]).map(team => ({
     ...team,
-    authorId: team.authorId || "1"
+    authorId: team.authorId || "1",
+    members: team.members || [{
+      userId: team.authorId || "1",
+      userName: "Alice", // Default for initial data if unknown
+      role: 'LEADER',
+      joinedAt: team.createdAt || new Date().toISOString()
+    }]
   })) as Team[]
   
   localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(initialTeams))
@@ -22,6 +28,15 @@ const getStoredTeams = (): Team[] => {
 
 const saveTeams = (teams: Team[]) => {
   localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(teams))
+}
+
+const getStoredInvites = (): TeamInvite[] => {
+  const stored = localStorage.getItem(INVITES_STORAGE_KEY)
+  return stored ? JSON.parse(stored) : []
+}
+
+const saveInvites = (invites: TeamInvite[]) => {
+  localStorage.setItem(INVITES_STORAGE_KEY, JSON.stringify(invites))
 }
 
 export const getTeams = async (hackathonSlug?: string): Promise<Team[]> => {
@@ -40,14 +55,21 @@ export const getTeamByCode = async (code: string): Promise<Team | undefined> => 
 }
 
 export const createTeam = async (
-  team: Omit<Team, "teamCode" | "createdAt">
+  team: Omit<Team, "teamCode" | "createdAt" | "members"> & { leaderName?: string }
 ): Promise<Team> => {
   const teams = getStoredTeams()
+  const { leaderName, ...teamData } = team;
   const newTeam: Team = {
     teamCode: `T-${Date.now().toString().slice(-6)}`,
     createdAt: new Date().toISOString(),
-    ...team
-  }
+    members: [{
+      userId: team.authorId,
+      userName: leaderName || "Leader",
+      role: 'LEADER',
+      joinedAt: new Date().toISOString()
+    }],
+    ...teamData
+  } as Team
 
   const updatedTeams = [newTeam, ...teams]
   saveTeams(updatedTeams)
@@ -72,4 +94,69 @@ export const deleteTeam = async (teamCode: string): Promise<void> => {
   const teams = getStoredTeams()
   const updatedTeams = teams.filter((t) => t.teamCode !== teamCode)
   saveTeams(updatedTeams)
+}
+
+// Invitation APIs
+export const inviteUser = async (invite: Omit<TeamInvite, "id" | "status" | "createdAt">): Promise<TeamInvite> => {
+  const invites = getStoredInvites()
+  const newInvite: TeamInvite = {
+    id: `INV-${Date.now().toString().slice(-6)}`,
+    status: 'PENDING',
+    createdAt: new Date().toISOString(),
+    ...invite
+  }
+  saveInvites([...invites, newInvite])
+  return newInvite
+}
+
+export const getInvitesForUser = async (userId: string): Promise<TeamInvite[]> => {
+  const invites = getStoredInvites()
+  return invites.filter(inv => inv.invitedUserId === userId)
+}
+
+export const getInvitesByTeam = async (teamId: string): Promise<TeamInvite[]> => {
+  const invites = getStoredInvites()
+  return invites.filter(inv => inv.teamId === teamId)
+}
+
+export const respondToInvite = async (inviteId: string, status: 'ACCEPTED' | 'REJECTED'): Promise<TeamInvite> => {
+  const invites = getStoredInvites()
+  const index = invites.findIndex(inv => inv.id === inviteId)
+  if (index === -1) throw new Error("Invite not found")
+  if (invites[index].status !== 'PENDING') throw new Error("Invite already processed")
+
+  const updatedInvite = { ...invites[index], status }
+  invites[index] = updatedInvite
+  saveInvites(invites)
+
+  if (status === 'ACCEPTED') {
+    const teams = getStoredTeams()
+    const teamIndex = teams.findIndex(t => t.teamCode === updatedInvite.teamId)
+    if (teamIndex !== -1) {
+      const team = teams[teamIndex]
+      const newMember: TeamMember = {
+        userId: updatedInvite.invitedUserId,
+        userName: updatedInvite.invitedUserName,
+        role: 'MEMBER',
+        joinedAt: new Date().toISOString()
+      }
+      team.members = [...(team.members || []), newMember]
+      team.memberCount = team.members.length
+      saveTeams(teams)
+    }
+  }
+
+  return updatedInvite
+}
+
+export const kickMember = async (teamCode: string, userId: string): Promise<Team> => {
+  const teams = getStoredTeams()
+  const index = teams.findIndex(t => t.teamCode === teamCode)
+  if (index === -1) throw new Error("Team not found")
+
+  const team = teams[index]
+  team.members = team.members.filter(m => m.userId !== userId)
+  team.memberCount = team.members.length
+  saveTeams(teams)
+  return team
 }

--- a/src/components/profile/NotificationPanel.tsx
+++ b/src/components/profile/NotificationPanel.tsx
@@ -1,0 +1,74 @@
+import { useUser } from '../../contexts/UserContext';
+import { useUserInvites, useRespondToInvite } from '../../hooks/useTeams';
+
+export default function NotificationPanel() {
+  const { user } = useUser();
+  const { data: invites, isLoading } = useUserInvites(user?.id || '');
+  const respondMutation = useRespondToInvite();
+
+  if (!user || isLoading) return null;
+
+  // 보낸 초대 중 처리되지 않은(PENDING) 것과 최근 처리된 것들을 표시
+  const pendingInvites = invites?.filter(inv => inv.status === 'PENDING') || [];
+  const processedInvites = invites?.filter(inv => inv.status !== 'PENDING').slice(-2) || []; // 최근 처리된 2개만 표시
+
+  if (pendingInvites.length === 0 && processedInvites.length === 0) return null;
+
+  const handleRespond = (inviteId: string, status: 'ACCEPTED' | 'REJECTED') => {
+    if (window.confirm(`초대를 ${status === 'ACCEPTED' ? '수락' : '거절'}하시겠습니까?`)) {
+      respondMutation.mutate({ inviteId, status });
+    }
+  };
+
+  return (
+    <div style={{ marginTop: 24, borderTop: '1px solid #eee', paddingTop: 20 }}>
+      <h3 style={{ margin: '0 0 12px 0', fontSize: 16, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}>
+        🔔 알림
+        {pendingInvites.length > 0 && (
+          <span style={{ backgroundColor: '#ef4444', color: 'white', fontSize: 10, padding: '2px 6px', borderRadius: 10 }}>
+            {pendingInvites.length}
+          </span>
+        )}
+      </h3>
+      
+      <div style={{ display: 'grid', gap: 10 }}>
+        {/* 대기 중인 초대 */}
+        {pendingInvites.map((inv) => (
+          <div key={inv.id} style={{ backgroundColor: '#f0f9ff', padding: 12, borderRadius: 8, border: '1px solid #bae6fd' }}>
+            <p style={{ margin: '0 0 8px 0', fontSize: 14 }}>
+              <strong>{inv.teamName}</strong> 팀에서 초대했습니다!
+            </p>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <button 
+                onClick={() => handleRespond(inv.id, 'ACCEPTED')}
+                disabled={respondMutation.isPending}
+                style={{ flex: 1, backgroundColor: '#10b981', color: 'white', border: 'none', padding: '6px', borderRadius: 4, fontSize: 13, cursor: 'pointer' }}
+              >
+                수락
+              </button>
+              <button 
+                onClick={() => handleRespond(inv.id, 'REJECTED')}
+                disabled={respondMutation.isPending}
+                style={{ flex: 1, backgroundColor: '#ef4444', color: 'white', border: 'none', padding: '6px', borderRadius: 4, fontSize: 13, cursor: 'pointer' }}
+              >
+                거절
+              </button>
+            </div>
+          </div>
+        ))}
+
+        {/* 최근 처리된 초대 (읽기 전용) */}
+        {processedInvites.map((inv) => (
+          <div key={inv.id} style={{ backgroundColor: '#f9fafb', padding: 10, borderRadius: 8, border: '1px solid #e5e7eb', opacity: 0.8 }}>
+            <p style={{ margin: 0, fontSize: 13, color: '#666' }}>
+              <strong>{inv.teamName}</strong> 팀 초대: 
+              <span style={{ marginLeft: 5, fontWeight: 'bold', color: inv.status === 'ACCEPTED' ? '#059669' : '#dc2626' }}>
+                {inv.status === 'ACCEPTED' ? '수락됨' : '거절됨'}
+              </span>
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/ProfileSidebar.tsx
+++ b/src/components/profile/ProfileSidebar.tsx
@@ -1,6 +1,7 @@
 import { useUser } from '../../contexts/UserContext'
 import LoginForm from './LoginForm'
 import UserProfile from './UserProfile'
+import NotificationPanel from './NotificationPanel'
 import { useEffect, useRef, useState } from 'react'
 
 type Props = {
@@ -71,7 +72,12 @@ export default function ProfileSidebar({ chatOpen }: Props) {
         {isLoggedIn ? '마이페이지' : '로그인'}
       </h2>
 
-      {isLoggedIn ? <UserProfile /> : <LoginForm />}
+      {isLoggedIn ? (
+        <>
+          <UserProfile />
+          <NotificationPanel />
+        </>
+      ) : <LoginForm />}
     </div>
   )
 }

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -34,7 +34,7 @@ type UserWithPassword = User & {
 const USER_STORAGE_KEY = 'logged_in_user'
 
 // 모든 유저 데이터를 하나의 배열로 관리
-const allUsers: UserWithPassword[] = [userAlice, userBob, userCharlie, userDiana, userEvan]
+export const allUsers: UserWithPassword[] = [userAlice, userBob, userCharlie, userDiana, userEvan]
 
 const loadUserFromStorage = (): User | null => {
   const raw = localStorage.getItem(USER_STORAGE_KEY)

--- a/src/features/Teams.tsx
+++ b/src/features/Teams.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useTeams, useUpdateTeam } from '../hooks/useTeams'
+import { useTeams, useUpdateTeam, useUserInvites, useRespondToInvite } from '../hooks/useTeams'
 import { useUser } from '../contexts/UserContext'
 
 type TeamsProps = {
@@ -12,6 +12,8 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
   const { user } = useUser()
   const { data: teams, isLoading } = useTeams(hackathonSlug)
   const { data: allTeams } = useTeams() // 내 팀을 찾기 위해 전체 목록 가져오기
+  const { data: userInvites } = useUserInvites(user?.id || '')
+  const respondMutation = useRespondToInvite()
   const updateMutation = useUpdateTeam()
   
   const [noticeOpen, setNoticeOpen] = useState(false)
@@ -49,6 +51,12 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
     }
   }
 
+  const handleRespond = (inviteId: string, status: 'ACCEPTED' | 'REJECTED') => {
+    if (window.confirm(`초대를 ${status === 'ACCEPTED' ? '수락' : '거절'}하시겠습니까? 한번 선택하면 변경할 수 없습니다.`)) {
+      respondMutation.mutate({ inviteId, status });
+    }
+  };
+
   return (
     <section>
       <h2>Teams</h2>
@@ -73,19 +81,74 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
       ) : !teams || teams.length === 0 ? (
         <p>등록된 팀이 없습니다.</p>
       ) : (
-        teams.map((team) => (
-          <article
-            key={team.teamCode}
-            style={{ border: '1px solid #ccc', padding: 12, marginBottom: 8 }}
-          >
-            <h3>{team.name}</h3>
-            <p>{team.intro}</p>
-            <p>Members: {team.memberCount}명</p>
-            <p>Status: {team.isOpen ? '모집중' : '모집마감'}</p>
-            <p>Looking For: {team.lookingFor.join(', ') || '-'}</p>
-            <p>Contact: {team.contact.url}</p>
-          </article>
-        ))
+        teams.map((team) => {
+          // 해당 팀에서 온 초대 중 PENDING인 것을 먼저 찾고, 없으면 가장 최근의 것을 찾음
+          const teamInvites = userInvites?.filter(inv => inv.teamId === team.teamCode) || [];
+          const invite = teamInvites.find(inv => inv.status === 'PENDING') || 
+                         (teamInvites.length > 0 ? [...teamInvites].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0] : null);
+          
+          const isLeader = team.authorId === user?.id;
+          
+          return (
+            <article
+              key={team.teamCode}
+              style={{ border: '1px solid #ccc', padding: 12, marginBottom: 8, borderRadius: 8 }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'start' }}>
+                <div>
+                  <h3>{team.name}</h3>
+                  <p>{team.intro}</p>
+                  <p>Members: {team.memberCount}명</p>
+                  <p>Status: {team.isOpen ? '모집중' : '모집마감'}</p>
+                  <p>Looking For: {team.lookingFor.join(', ') || '-'}</p>
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  {isLeader && (
+                    <button 
+                      onClick={() => navigate(`/team/${team.teamCode}/manage`)}
+                      style={{ backgroundColor: '#3b82f6', color: 'white', border: 'none', padding: '8px 12px', borderRadius: 4, cursor: 'pointer' }}
+                    >
+                      관리
+                    </button>
+                  )}
+                  
+                  {invite && (
+                    <div style={{ border: '1px solid #eee', padding: 8, borderRadius: 4, backgroundColor: '#f9fafb' }}>
+                      <p style={{ margin: '0 0 8px 0', fontSize: '0.85rem', fontWeight: 'bold' }}>팀 초대</p>
+                      {invite.status === 'PENDING' ? (
+                        <div style={{ display: 'flex', gap: 4 }}>
+                          <button 
+                            onClick={() => handleRespond(invite.id, 'ACCEPTED')}
+                            disabled={respondMutation.isPending}
+                            style={{ backgroundColor: '#10b981', color: 'white', border: 'none', padding: '4px 8px', borderRadius: 4, fontSize: '0.8rem', cursor: 'pointer' }}
+                          >
+                            수락
+                          </button>
+                          <button 
+                            onClick={() => handleRespond(invite.id, 'REJECTED')}
+                            disabled={respondMutation.isPending}
+                            style={{ backgroundColor: '#ef4444', color: 'white', border: 'none', padding: '4px 8px', borderRadius: 4, fontSize: '0.8rem', cursor: 'pointer' }}
+                          >
+                            거절
+                          </button>
+                        </div>
+                      ) : (
+                        <span style={{ 
+                          fontSize: '0.85rem', 
+                          fontWeight: 'bold',
+                          color: invite.status === 'ACCEPTED' ? '#10b981' : '#ef4444' 
+                        }}>
+                          {invite.status === 'ACCEPTED' ? '초대 수락됨' : '초대 거절됨'}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+              <p style={{ marginTop: 10, fontSize: '0.9rem', color: '#666' }}>Contact: {team.contact.url}</p>
+            </article>
+          );
+        })
       )}
 
       {/* 팀 생성 안내 모달 */}

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -1,6 +1,17 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
-import { getTeams, updateTeam, getTeamByCode, deleteTeam, createTeam } from "../api/teamApi"
-import type { Team } from "../types/team"
+import { 
+  getTeams, 
+  updateTeam, 
+  getTeamByCode, 
+  deleteTeam, 
+  createTeam, 
+  inviteUser, 
+  getInvitesForUser, 
+  getInvitesByTeam, 
+  respondToInvite, 
+  kickMember 
+} from "../api/teamApi"
+import type { Team, TeamInvite } from "../types/team"
 
 export const useTeams = (hackathonSlug?: string) => {
   return useQuery({
@@ -20,7 +31,7 @@ export const useTeam = (teamCode: string) => {
 export const useCreateTeam = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (team: Omit<Team, "teamCode" | "createdAt">) => createTeam(team),
+    mutationFn: (team: Omit<Team, "teamCode" | "createdAt" | "members"> & { leaderName?: string }) => createTeam(team),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["teams"] })
     }
@@ -45,6 +56,57 @@ export const useDeleteTeam = () => {
     mutationFn: (teamCode: string) => deleteTeam(teamCode),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["teams"] })
+    }
+  })
+}
+
+export const useInviteUser = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (invite: Omit<TeamInvite, "id" | "status" | "createdAt">) => inviteUser(invite),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["invites", "team", variables.teamId] })
+    }
+  })
+}
+
+export const useUserInvites = (userId: string) => {
+  return useQuery({
+    queryKey: ["invites", "user", userId],
+    queryFn: () => getInvitesForUser(userId),
+    enabled: !!userId
+  })
+}
+
+export const useTeamInvites = (teamId: string) => {
+  return useQuery({
+    queryKey: ["invites", "team", teamId],
+    queryFn: () => getInvitesByTeam(teamId),
+    enabled: !!teamId
+  })
+}
+
+export const useRespondToInvite = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ inviteId, status }: { inviteId: string; status: 'ACCEPTED' | 'REJECTED' }) => 
+      respondToInvite(inviteId, status),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["invites", "user", data.invitedUserId] })
+      queryClient.invalidateQueries({ queryKey: ["invites", "team", data.teamId] })
+      queryClient.invalidateQueries({ queryKey: ["teams"] })
+      queryClient.invalidateQueries({ queryKey: ["team", data.teamId] })
+    }
+  })
+}
+
+export const useKickMember = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ teamCode, userId }: { teamCode: string; userId: string }) => kickMember(teamCode, userId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["teams"] })
+      queryClient.invalidateQueries({ queryKey: ["team", variables.teamCode] })
     }
   })
 }

--- a/src/pages/Camp.tsx
+++ b/src/pages/Camp.tsx
@@ -95,6 +95,12 @@ export default function Camp() {
                         수정
                       </button>
                     </Link>
+
+                    <Link to={`/team/${team.teamCode}/manage`}>
+                      <button style={{ backgroundColor: "#3b82f6", color: "white" }}>
+                        팀 관리
+                      </button>
+                    </Link>
                   </>
                 )}
               </div>

--- a/src/pages/CampCreate.tsx
+++ b/src/pages/CampCreate.tsx
@@ -63,7 +63,8 @@ export default function CampCreate() {
         url: contactUrl
       },
       hackathonSlug: hackathonSlug || undefined,
-      authorId: user.id
+      authorId: user.id,
+      leaderName: user.nickname
     }, {
       onSuccess: () => {
         navigate(hackathonSlug ? `/camp?hackathon=${hackathonSlug}` : "/camp")

--- a/src/pages/TeamManagement.tsx
+++ b/src/pages/TeamManagement.tsx
@@ -1,0 +1,144 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useTeam, useKickMember, useInviteUser, useTeamInvites } from '../hooks/useTeams';
+import { useUser, allUsers } from '../contexts/UserContext';
+import { useState } from 'react';
+
+export default function TeamManagement() {
+  const { teamCode } = useParams<{ teamCode: string }>();
+  const navigate = useNavigate();
+  const { user } = useUser();
+  const { data: team, isLoading } = useTeam(teamCode || '');
+  const { data: invites } = useTeamInvites(teamCode || '');
+  const kickMutation = useKickMember();
+  const inviteMutation = useInviteUser();
+
+  const [inviteUserName, setInviteUserName] = useState('');
+
+  if (isLoading) return <div style={{ padding: 20 }}>Loading...</div>;
+  if (!team) return <div style={{ padding: 20 }}>Team not found.</div>;
+
+  const isLeader = team.authorId === user?.id;
+
+  const handleKick = (userId: string) => {
+    if (window.confirm('정말 이 팀원을 내보내시겠습니까?')) {
+      kickMutation.mutate({ teamCode: team.teamCode, userId });
+    }
+  };
+
+  const handleInvite = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inviteUserName) {
+      alert('초대할 유저의 이름을 입력해주세요.');
+      return;
+    }
+
+    const targetUser = allUsers.find(u => u.nickname === inviteUserName);
+    if (!targetUser) {
+      alert('존재하지 않는 유저입니다.');
+      return;
+    }
+
+    if (team.members?.some(m => m.userId === targetUser.id)) {
+      alert('이미 팀에 소속된 유저입니다.');
+      return;
+    }
+    
+    inviteMutation.mutate({
+      teamId: team.teamCode,
+      teamName: team.name,
+      invitedUserId: targetUser.id,
+      invitedUserName: targetUser.nickname,
+    }, {
+      onSuccess: () => {
+        alert(`${targetUser.nickname}님에게 초대를 보냈습니다.`);
+        setInviteUserName('');
+      }
+    });
+  };
+
+  return (
+    <div style={{ maxWidth: 800, margin: '0 auto', padding: 20 }}>
+      <button onClick={() => navigate(-1)} style={{ marginBottom: 20 }}>&larr; 뒤로가기</button>
+      
+      <h1>팀 관리: {team.name}</h1>
+      <p>{team.intro}</p>
+
+      <section style={{ marginTop: 30 }}>
+        <h2>팀원 목록 ({team.memberCount}명)</h2>
+        <div style={{ display: 'grid', gap: 10 }}>
+          {team.members?.map((member) => (
+            <div key={member.userId} style={{ border: '1px solid #ddd', padding: 12, borderRadius: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <strong>{member.userName}</strong> ({member.userId})
+                <span style={{ marginLeft: 10, fontSize: '0.8rem', color: '#666' }}>
+                  {member.role === 'LEADER' ? '👑 팀장' : '멤버'} | 합류일: {new Date(member.joinedAt).toLocaleDateString()}
+                </span>
+              </div>
+              {isLeader && member.role !== 'LEADER' && (
+                <button 
+                  onClick={() => handleKick(member.userId)}
+                  style={{ backgroundColor: '#ef4444', color: 'white', border: 'none', padding: '4px 8px', borderRadius: 4, cursor: 'pointer' }}
+                >
+                  내보내기
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {isLeader && (
+        <section style={{ marginTop: 40, padding: 20, backgroundColor: '#f9f9f9', borderRadius: 8 }}>
+          <h2>새 팀원 초대</h2>
+          <form onSubmit={handleInvite} style={{ display: 'flex', gap: 10 }}>
+            <input 
+              type="text" 
+              placeholder="초대할 유저의 닉네임 입력" 
+              value={inviteUserName}
+              onChange={(e) => setInviteUserName(e.target.value)}
+              style={{ padding: 8, flex: 1 }}
+            />
+            <button type="submit" style={{ padding: '8px 16px' }}>초대 보내기</button>
+          </form>
+
+          <div style={{ marginTop: 20 }}>
+            <h3>보낸 초대 현황</h3>
+            {invites && invites.length > 0 ? (
+              <ul style={{ listStyle: 'none', padding: 0 }}>
+                {[...invites].reverse().map((inv) => (
+                  <li key={inv.id} style={{ padding: '8px 0', borderBottom: '1px solid #eee' }}>
+                    {inv.invitedUserName} ({inv.invitedUserId}) - 
+                    <span style={{ 
+                      marginLeft: 8, 
+                      fontWeight: 'bold',
+                      color: inv.status === 'PENDING' ? '#f59e0b' : inv.status === 'ACCEPTED' ? '#10b981' : '#ef4444' 
+                    }}>
+                      {inv.status}
+                    </span>
+                    <span style={{ marginLeft: 10, fontSize: '0.75rem', color: '#999' }}>
+                      {new Date(inv.createdAt).toLocaleString()}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p style={{ color: '#666', fontSize: '0.9rem' }}>보낸 초대가 없습니다.</p>
+            )}
+          </div>
+        </section>
+      )}
+
+      <section style={{ marginTop: 40 }}>
+        <h2>참가한 해커톤</h2>
+        {team.hackathonSlug ? (
+          <div style={{ border: '1px solid #10b981', padding: 15, borderRadius: 8, backgroundColor: '#ecfdf5' }}>
+            <h3 style={{ margin: 0 }}>{team.hackathonSlug}</h3>
+            <p style={{ marginBottom: 0 }}>현재 이 해커톤에 참여 중입니다.</p>
+          </div>
+        ) : (
+          <p>현재 참여 중인 해커톤이 없습니다.</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -7,6 +7,7 @@ import Rankings from '../pages/Rankings'
 import CampCreate from "../pages/CampCreate"
 import CampEdit from "../pages/CampEdit"
 import Analytics from "../pages/Analytics"
+import TeamManagement from "../pages/TeamManagement"
 
 export const router = createBrowserRouter([
   { path: '/', element: <Home /> },
@@ -16,5 +17,6 @@ export const router = createBrowserRouter([
   { path: '/rankings', element: <Rankings /> },
   { path: "/camp/new", element: <CampCreate /> },
   { path: "/camp/edit/:id", element: <CampEdit /> },
-  { path: "/analytics", element: <Analytics /> }
+  { path: "/analytics", element: <Analytics /> },
+  { path: "/team/:teamCode/manage", element: <TeamManagement /> }
 ])

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -1,10 +1,31 @@
+export type InviteStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED';
+
+export interface TeamMember {
+  userId: string;
+  userName: string;
+  role: 'LEADER' | 'MEMBER';
+  joinedAt: string;
+}
+
+export interface TeamInvite {
+  id: string;
+  teamId: string;
+  teamName: string;
+  invitedUserId: string;
+  invitedUserName: string;
+  status: InviteStatus;
+  createdAt: string;
+}
+
 export interface Team {
   teamCode: string
+  authorId: string
   hackathonSlug?: string
   name: string
   intro: string
   isOpen: boolean
   memberCount: number
+  members: TeamMember[]
   lookingFor: string[]
   contact: {
     type: string


### PR DESCRIPTION
 1. 팀 관리 기능 (Team Management)
   * 신규 페이지 추가: /team/:teamCode/manage 경로에 팀 관리 전용 페이지 구현.
   * 멤버 관리: 팀장 권한으로 팀원 목록을 확인하고, 멤버를 내보내는(Kick) 기능 추가.
   * 팀 생성 로직 개선: 팀 생성 시 제작자가 자동으로 '팀장' 권한을 가진 첫 번째 멤버로 등록되도록
     수정.


  2. 고도화된 초대 시스템 (Invitation System)
   * 닉네임 기반 초대: 유저 ID 대신 닉네임으로 검색하여 초대를 보낼 수 있으며, 존재하지 않는 유저 입력
     시 유효성 검사(알림 팝업) 처리.
   * 초대 상태 고정: 수락 또는 거절을 한 번 선택하면 상태가 고정되어 이후 변경이 불가능하도록 설계
     (데이터 무결성 확보).
   * 중복 초대 해결: 재초대 시 '이미 수락됨'으로 표시되는 문제를 해결하기 위해, 가장 최신 또는 대기
     중(PENDING)인 초대를 우선 참조하도록 로직 강화.


  3. 통합 알림창 (Notification Panel)
   * 마이페이지 연동: 로그인 창 하단(Profile Sidebar)에 알림 섹션 신규 추가.
   * 범용성: 해커톤 연결 여부와 관계없이 나에게 온 모든 팀 초대를 한눈에 확인하고 즉시 수락/거절 가능.
   * 실시간 배지: 새로운 초대 발생 시 알림 개수 배지 표시.


  4. UI/UX 개선
   * 접근성 향상: /camp 목록 및 해커톤 상세 페이지의 팀 카드에 [팀 관리] 버튼을 추가하여 관리 페이지
     진입로 확보.
   * 사용자 피드백: 초대 발송, 수락, 거절, 멤버 추방 등 주요 액션에 대한 안내 메시지(alert) 강화.


  5. 기술적 변경 사항
   * API & Hooks: teamApi 확장 및 React Query를 활용한 커스텀 훅(useInviteUser, useRespondToInvite 등)
     구현.
   * Data Types: TeamMember, TeamInvite, InviteStatus 등 신규 타입 정의.