### PR TITLE
feat: 리더보드 페이지 기능 구현 및 해커톤페이지 ui 일부변경

### DIFF
--- a/src/features/Leaderboard.tsx
+++ b/src/features/Leaderboard.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react'
-import hackathonDetailData from '../data/public_hackathon_detail.json'
 
 type LeaderboardProps = {
   hackathonSlug: string
@@ -11,48 +10,26 @@ type Team = {
   name: string
 }
 
-type Submission = {
-  hackathonSlug?: string
-  teamId?: string
-  teamName?: string
-}
-
-type EvalBreakdownItem = {
-  key: string
-  weightPercent: number
-}
-
-type EvalSection = {
-  scoreDisplay?: {
-    breakdown?: EvalBreakdownItem[]
-  }
-}
-
-type HackathonDetailItem = {
-  slug: string
-  sections?: {
-    eval?: EvalSection
-  }
+type LeaderboardSubmission = {
+  submissionId: string
+  hackathonSlug: string
+  teamId: string
+  submittedAt: string
+  totalScore: number
 }
 
 type LeaderboardRow = {
   teamId: string
   teamName: string
-  score: number | null
+  bestScore: number | null
+  bestSubmittedAt: string | null
+  submissionCount: number
   status: '제출' | '미제출'
   rank: number | null
 }
 
 const TEAMS_STORAGE_KEY = 'teams'
-const SUBMISSIONS_STORAGE_KEY = 'submissions'
-
-function hashTo100(seed: string): number {
-  let hash = 0
-  for (let index = 0; index < seed.length; index += 1) {
-    hash = (hash * 31 + seed.charCodeAt(index)) % 101
-  }
-  return hash
-}
+const LEADERBOARD_SUBMISSIONS_STORAGE_KEY = 'leaderboard_submissions'
 
 function normalizeTeam(item: unknown): Team | null {
   if (typeof item !== 'object' || item === null) return null
@@ -87,118 +64,184 @@ function getTeamsFromStorage(): Team[] {
   }
 }
 
-function normalizeSubmission(item: unknown): Submission | null {
+function normalizeLeaderboardSubmission(item: unknown): LeaderboardSubmission | null {
   if (typeof item !== 'object' || item === null) return null
   const candidate = item as Record<string, unknown>
-  const hackathonSlug =
-    typeof candidate.hackathonSlug === 'string' ? candidate.hackathonSlug : undefined
-  const teamId = typeof candidate.teamId === 'string' ? candidate.teamId : undefined
-  const teamName = typeof candidate.teamName === 'string' ? candidate.teamName : undefined
-  return { hackathonSlug, teamId, teamName }
+  const submissionId = typeof candidate.submissionId === 'string' ? candidate.submissionId : ''
+  const hackathonSlug = typeof candidate.hackathonSlug === 'string' ? candidate.hackathonSlug : ''
+  const teamId = typeof candidate.teamId === 'string' ? candidate.teamId : ''
+  const submittedAt = typeof candidate.submittedAt === 'string' ? candidate.submittedAt : ''
+  const totalScore =
+    typeof candidate.totalScore === 'number' && Number.isFinite(candidate.totalScore)
+      ? candidate.totalScore
+      : NaN
+
+  if (!submissionId || !hackathonSlug || !teamId || !submittedAt || Number.isNaN(totalScore)) {
+    return null
+  }
+
+  return { submissionId, hackathonSlug, teamId, submittedAt, totalScore }
 }
 
-function getSubmissionsFromStorage(): Submission[] {
-  const raw = localStorage.getItem(SUBMISSIONS_STORAGE_KEY)
+function getLeaderboardSubmissionsFromStorage(): LeaderboardSubmission[] {
+  const raw = localStorage.getItem(LEADERBOARD_SUBMISSIONS_STORAGE_KEY)
   if (!raw) return []
   try {
     const parsed = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
     return parsed
-      .map((item) => normalizeSubmission(item))
-      .filter((item): item is Submission => item !== null)
+      .map((item) => normalizeLeaderboardSubmission(item))
+      .filter((item): item is LeaderboardSubmission => item !== null)
   } catch {
     return []
   }
 }
 
-function getEvalSectionBySlug(slug: string): EvalSection | null {
-  const details = hackathonDetailData as HackathonDetailItem[]
-  const detail = details.find((item) => item.slug === slug)
-  return detail?.sections?.eval ?? null
+function toTimestamp(value: string): number {
+  const parsed = new Date(value).getTime()
+  return Number.isNaN(parsed) ? Number.MAX_SAFE_INTEGER : parsed
 }
 
-function getScoreForTeam(teamId: string, breakdown: EvalBreakdownItem[] | undefined): number {
-  if (!breakdown || breakdown.length === 0) {
-    return hashTo100(`score:${teamId}`)
+function chooseBestSubmission(
+  left: LeaderboardSubmission,
+  right: LeaderboardSubmission
+): LeaderboardSubmission {
+  if (left.totalScore !== right.totalScore) {
+    return left.totalScore > right.totalScore ? left : right
   }
+  return toTimestamp(left.submittedAt) <= toTimestamp(right.submittedAt) ? left : right
+}
 
-  const total = breakdown.reduce((sum, item) => {
-    const voteValue = hashTo100(`${item.key}:${teamId}`)
-    const weight = (Number(item.weightPercent) || 0) / 100
-    return sum + voteValue * weight
-  }, 0)
-  return Math.round(total)
+function formatDateTime(value: string | null): string {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
+function formatScore(value: number | null): string {
+  if (value === null) return '-'
+  return Number.isInteger(value) ? String(value) : value.toFixed(1)
 }
 
 export default function Leaderboard({ hackathonSlug }: LeaderboardProps) {
   const rows = useMemo(() => {
     const teams = getTeamsFromStorage().filter((team) => team.hackathonSlug === hackathonSlug)
-    const submissions = getSubmissionsFromStorage().filter(
+    const submissions = getLeaderboardSubmissionsFromStorage().filter(
       (submission) => submission.hackathonSlug === hackathonSlug
     )
-    const breakdown = getEvalSectionBySlug(hackathonSlug)?.scoreDisplay?.breakdown
+
+    const submissionsByTeam = new Map<string, LeaderboardSubmission[]>()
+    submissions.forEach((submission) => {
+      const current = submissionsByTeam.get(submission.teamId) ?? []
+      current.push(submission)
+      submissionsByTeam.set(submission.teamId, current)
+    })
 
     const baseRows: LeaderboardRow[] = teams.map((team) => {
-      const hasSubmission = submissions.some(
-        (submission) =>
-          submission.teamId === team.id ||
-          (submission.teamName && submission.teamName === team.name)
-      )
-
-      if (!hasSubmission) {
+      const teamSubmissions = submissionsByTeam.get(team.id) ?? []
+      if (teamSubmissions.length === 0) {
         return {
           teamId: team.id,
           teamName: team.name,
-          score: null,
+          bestScore: null,
+          bestSubmittedAt: null,
+          submissionCount: 0,
           status: '미제출',
           rank: null,
         }
       }
 
+      const bestSubmission = teamSubmissions.reduce((best, current) =>
+        chooseBestSubmission(best, current)
+      )
       return {
         teamId: team.id,
         teamName: team.name,
-        score: getScoreForTeam(team.id, breakdown),
+        bestScore: bestSubmission.totalScore,
+        bestSubmittedAt: bestSubmission.submittedAt,
+        submissionCount: teamSubmissions.length,
         status: '제출',
         rank: null,
       }
     })
 
     const ranked = baseRows
-      .filter((row) => row.status === '제출' && row.score !== null)
-      .sort((a, b) => (b.score ?? -1) - (a.score ?? -1))
+      .filter((row) => row.status === '제출' && row.bestScore !== null)
+      .sort((a, b) => {
+        if ((a.bestScore ?? -1) !== (b.bestScore ?? -1)) {
+          return (b.bestScore ?? -1) - (a.bestScore ?? -1)
+        }
+        return toTimestamp(a.bestSubmittedAt ?? '') - toTimestamp(b.bestSubmittedAt ?? '')
+      })
       .map((row, index) => ({ ...row, rank: index + 1 }))
 
     const rankByTeamId = new Map(ranked.map((row) => [row.teamId, row.rank]))
-    return baseRows.map((row) => ({
-      ...row,
-      rank: row.status === '제출' ? (rankByTeamId.get(row.teamId) ?? null) : null,
-    }))
+    return baseRows
+      .map((row) => ({
+        ...row,
+        rank: row.status === '제출' ? (rankByTeamId.get(row.teamId) ?? null) : null,
+      }))
+      .sort((a, b) => {
+        if (a.rank !== null && b.rank !== null) return a.rank - b.rank
+        if (a.rank !== null) return -1
+        if (b.rank !== null) return 1
+        return a.teamName.localeCompare(b.teamName)
+      })
   }, [hackathonSlug])
 
   return (
-    <section>
-      <h2>Leaderboard</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>Rank</th>
-            <th>Team name</th>
-            <th>Score</th>
-            <th>Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.teamId}>
-              <td>{row.rank ?? '-'}</td>
-              <td>{row.teamName}</td>
-              <td>{row.score ?? '-'}</td>
-              <td>{row.status}</td>
+    <section style={{ marginTop: 12 }}>
+      <h2 style={{ marginBottom: 12 }}>Leaderboard</h2>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'separate', borderSpacing: 0 }}>
+          <thead>
+            <tr style={{ backgroundColor: '#f8f9fa' }}>
+              <th style={{ padding: '12px 14px', textAlign: 'left', borderBottom: '2px solid #dee2e6' }}>
+                Rank
+              </th>
+              <th style={{ padding: '12px 14px', textAlign: 'left', borderBottom: '2px solid #dee2e6' }}>
+                Team name
+              </th>
+              <th style={{ padding: '12px 14px', textAlign: 'left', borderBottom: '2px solid #dee2e6' }}>
+                Score
+              </th>
+              <th style={{ padding: '12px 14px', textAlign: 'left', borderBottom: '2px solid #dee2e6' }}>
+                Submissions
+              </th>
+              <th style={{ padding: '12px 14px', textAlign: 'left', borderBottom: '2px solid #dee2e6' }}>
+                Best Submitted At
+              </th>
+              <th style={{ padding: '12px 14px', textAlign: 'left', borderBottom: '2px solid #dee2e6' }}>
+                Status
+              </th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {rows.map((row, index) => (
+              <tr
+                key={row.teamId}
+                style={{
+                  backgroundColor: index % 2 === 0 ? '#ffffff' : '#fcfcfd',
+                }}
+              >
+                <td style={{ padding: '11px 14px', borderBottom: '1px solid #eceff3' }}>{row.rank ?? '-'}</td>
+                <td style={{ padding: '11px 14px', borderBottom: '1px solid #eceff3' }}>{row.teamName}</td>
+                <td style={{ padding: '11px 14px', borderBottom: '1px solid #eceff3' }}>
+                  {formatScore(row.bestScore)}
+                </td>
+                <td style={{ padding: '11px 14px', borderBottom: '1px solid #eceff3' }}>
+                  {row.submissionCount}
+                </td>
+                <td style={{ padding: '11px 14px', borderBottom: '1px solid #eceff3' }}>
+                  {formatDateTime(row.bestSubmittedAt)}
+                </td>
+                <td style={{ padding: '11px 14px', borderBottom: '1px solid #eceff3' }}>{row.status}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </section>
   )
 }

--- a/src/features/Submit.tsx
+++ b/src/features/Submit.tsx
@@ -11,10 +11,20 @@ type SubmitSection = {
   guide?: string[]
 }
 
+type EvalBreakdownItem = {
+  key: string
+  weightPercent: number
+}
+
 type HackathonDetailItem = {
   slug: string
   sections?: {
     submit?: SubmitSection
+    eval?: {
+      scoreDisplay?: {
+        breakdown?: EvalBreakdownItem[]
+      }
+    }
   }
 }
 
@@ -28,8 +38,17 @@ type Submission = {
   teamName?: string
 }
 
+type LeaderboardSubmission = {
+  submissionId: string
+  hackathonSlug: string
+  teamId: string
+  submittedAt: string
+  totalScore: number
+}
+
 const SUBMISSIONS_STORAGE_KEY = 'submissions'
 const TEAMS_STORAGE_KEY = 'teams'
+const LEADERBOARD_SUBMISSIONS_STORAGE_KEY = 'leaderboard_submissions'
 const ACCEPT_BY_TYPE: Record<string, string> = {
   zip: '.zip,application/zip',
   pdf: '.pdf,application/pdf',
@@ -47,6 +66,12 @@ function getSubmitSectionBySlug(slug: string): SubmitSection | null {
   return detail?.sections?.submit ?? null
 }
 
+function getEvalBreakdownBySlug(slug: string): EvalBreakdownItem[] | undefined {
+  const details = hackathonDetailData as HackathonDetailItem[]
+  const detail = details.find((item) => item.slug === slug)
+  return detail?.sections?.eval?.scoreDisplay?.breakdown
+}
+
 function getSubmissionsFromStorage(): Submission[] {
   const raw = localStorage.getItem(SUBMISSIONS_STORAGE_KEY)
   if (!raw) return []
@@ -56,6 +81,48 @@ function getSubmissionsFromStorage(): Submission[] {
   } catch {
     return []
   }
+}
+
+function getLeaderboardSubmissionsFromStorage(): LeaderboardSubmission[] {
+  const raw = localStorage.getItem(LEADERBOARD_SUBMISSIONS_STORAGE_KEY)
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as LeaderboardSubmission[]) : []
+  } catch {
+    return []
+  }
+}
+
+function hashTo100(seed: string): number {
+  let hash = 0
+  for (let index = 0; index < seed.length; index += 1) {
+    hash = (hash * 31 + seed.charCodeAt(index)) % 101
+  }
+  return hash
+}
+
+function getTotalScore(
+  teamId: string,
+  submissionId: string,
+  breakdown: EvalBreakdownItem[] | undefined
+): number {
+  if (!breakdown || breakdown.length === 0) {
+    return hashTo100(`score:${teamId}:${submissionId}`)
+  }
+
+  const totalWeight = breakdown.reduce((sum, item) => sum + (Number(item.weightPercent) || 0), 0)
+  if (totalWeight <= 0) {
+    return hashTo100(`score:${teamId}:${submissionId}`)
+  }
+
+  const weightedSum = breakdown.reduce((sum, item) => {
+    const weight = Number(item.weightPercent) || 0
+    const score = hashTo100(`${item.key}:${teamId}:${submissionId}`)
+    return sum + score * weight
+  }, 0)
+
+  return Math.round((weightedSum / totalWeight) * 10) / 10
 }
 
 function getTeamOptionsFromStorage(hackathonSlug: string): TeamOption[] {
@@ -94,6 +161,7 @@ export default function Submit({ hackathonSlug }: SubmitProps) {
   const { recordEvent } = useLog()
   const submitSection = useMemo(() => getSubmitSectionBySlug(hackathonSlug), [hackathonSlug])
   const teamOptions = useMemo(() => getTeamOptionsFromStorage(hackathonSlug), [hackathonSlug])
+  const evalBreakdown = useMemo(() => getEvalBreakdownBySlug(hackathonSlug), [hackathonSlug])
   const allowedArtifactTypes = submitSection?.allowedArtifactTypes ?? []
   const defaultType = allowedArtifactTypes[0] ?? 'zip'
 
@@ -120,24 +188,45 @@ export default function Submit({ hackathonSlug }: SubmitProps) {
     }
 
     const selectedTeam = teamOptions.find((team) => team.id === teamId)
+    if (!selectedTeam) {
+      setMessage('제출할 팀을 선택해 주세요.')
+      return
+    }
+
+    const submittedAt = new Date().toISOString()
+    const submissionId = `LB-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+    const totalScore = getTotalScore(selectedTeam.id, submissionId, evalBreakdown)
 
     const newSubmission: Submission = {
       hackathonSlug,
       notes: notes.trim(),
       artifact,
-      createdAt: new Date().toISOString(),
+      createdAt: submittedAt,
       artifactType,
-      teamId: selectedTeam?.id,
-      teamName: selectedTeam?.name,
+      teamId: selectedTeam.id,
+      teamName: selectedTeam.name,
     }
 
     const submissions = getSubmissionsFromStorage()
     const updated = [...submissions, newSubmission]
     localStorage.setItem(SUBMISSIONS_STORAGE_KEY, JSON.stringify(updated))
 
+    const leaderboardSubmission: LeaderboardSubmission = {
+      submissionId,
+      hackathonSlug,
+      teamId: selectedTeam.id,
+      submittedAt,
+      totalScore,
+    }
+    const leaderboardSubmissions = getLeaderboardSubmissionsFromStorage()
+    localStorage.setItem(
+      LEADERBOARD_SUBMISSIONS_STORAGE_KEY,
+      JSON.stringify([leaderboardSubmission, ...leaderboardSubmissions])
+    )
+
     recordEvent('submit_project', 'hackathon', hackathonSlug, {
-      teamId: selectedTeam?.id,
-      teamName: selectedTeam?.name,
+      teamId: selectedTeam.id,
+      teamName: selectedTeam.name,
     })
 
     setNotes('')
@@ -148,90 +237,170 @@ export default function Submit({ hackathonSlug }: SubmitProps) {
   }
 
   return (
-    <section>
-      <h2>Submit</h2>
+    <section style={{ marginTop: 12 }}>
+      <h2 style={{ marginBottom: 12 }}>Submit</h2>
 
-      <h3>Submission Guide</h3>
-      {submitSection?.guide && submitSection.guide.length > 0 ? (
-        <ul>
-          {submitSection.guide.map((item, index) => (
-            <li key={`${item}-${index}`}>{item}</li>
-          ))}
-        </ul>
-      ) : (
-        <p>제출 가이드가 없습니다.</p>
-      )}
-
-      <form onSubmit={handleSubmit}>
-        <label htmlFor="submit-team">team: </label>
-        <select
-          id="submit-team"
-          value={teamId}
-          onChange={(event) => setTeamId(event.target.value)}
-          required
-        >
-          <option value="">팀을 선택하세요</option>
-          {teamOptions.map((team) => (
-            <option key={team.id} value={team.id}>
-              {team.name}
-            </option>
-          ))}
-        </select>
-        <br />
-
-        <textarea
-          placeholder="notes (optional)"
-          value={notes}
-          onChange={(event) => setNotes(event.target.value)}
-        />
-        <br />
-
-        <label htmlFor="artifact-type">artifact type: </label>
-        <select
-          id="artifact-type"
-          value={artifactType}
-          onChange={(event) => {
-            const nextType = event.target.value
-            setArtifactType(nextType)
-            setArtifactFile(null)
-            setArtifactUrl('')
-          }}
-        >
-          {allowedArtifactTypes.length > 0 ? (
-            allowedArtifactTypes.map((type) => (
-              <option key={type} value={type}>
-                {type}
-              </option>
-            ))
-          ) : (
-            <option value="zip">zip</option>
-          )}
-        </select>
-        <br />
-
-        {artifactType === 'url' ? (
-          <input
-            type="url"
-            placeholder="https://..."
-            value={artifactUrl}
-            onChange={(event) => setArtifactUrl(event.target.value)}
-            required
-          />
+      <div
+        style={{
+          border: '1px solid #e5e7eb',
+          borderRadius: 10,
+          padding: 16,
+          backgroundColor: '#fafafa',
+          marginBottom: 16,
+        }}
+      >
+        <h3 style={{ margin: '0 0 10px 0' }}>Submission Guide</h3>
+        {submitSection?.guide && submitSection.guide.length > 0 ? (
+          <ul style={{ margin: 0, paddingLeft: 20, lineHeight: 1.6 }}>
+            {submitSection.guide.map((item, index) => (
+              <li key={`${item}-${index}`}>{item}</li>
+            ))}
+          </ul>
         ) : (
-          <input
-            key={artifactType}
-            type="file"
-            accept={ACCEPT_BY_TYPE[artifactType] ?? ''}
-            onChange={(event) => setArtifactFile(event.target.files?.[0] ?? null)}
-            required
-          />
+          <p style={{ margin: 0 }}>제출 가이드가 없습니다.</p>
         )}
-        <br />
+      </div>
 
-        <button type="submit">submit</button>
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          border: '1px solid #e5e7eb',
+          borderRadius: 10,
+          padding: 16,
+          display: 'grid',
+          gap: 14,
+        }}
+      >
+        <div style={{ display: 'grid', gap: 6 }}>
+          <label htmlFor="submit-team" style={{ fontWeight: 600 }}>
+            Team
+          </label>
+          <select
+            id="submit-team"
+            value={teamId}
+            onChange={(event) => setTeamId(event.target.value)}
+            required
+            style={{
+              padding: '10px 12px',
+              border: '1px solid #d1d5db',
+              borderRadius: 8,
+              fontSize: 14,
+            }}
+          >
+            <option value="">팀을 선택하세요</option>
+            {teamOptions.map((team) => (
+              <option key={team.id} value={team.id}>
+                {team.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div style={{ display: 'grid', gap: 6 }}>
+          <label htmlFor="submit-notes" style={{ fontWeight: 600 }}>
+            Notes
+          </label>
+          <textarea
+            id="submit-notes"
+            placeholder="notes (optional)"
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            rows={5}
+            style={{
+              padding: '10px 12px',
+              border: '1px solid #d1d5db',
+              borderRadius: 8,
+              fontSize: 14,
+              resize: 'vertical',
+            }}
+          />
+        </div>
+
+        <div style={{ display: 'grid', gap: 6 }}>
+          <label htmlFor="artifact-type" style={{ fontWeight: 600 }}>
+            Artifact Type
+          </label>
+          <select
+            id="artifact-type"
+            value={artifactType}
+            onChange={(event) => {
+              const nextType = event.target.value
+              setArtifactType(nextType)
+              setArtifactFile(null)
+              setArtifactUrl('')
+            }}
+            style={{
+              padding: '10px 12px',
+              border: '1px solid #d1d5db',
+              borderRadius: 8,
+              fontSize: 14,
+            }}
+          >
+            {allowedArtifactTypes.length > 0 ? (
+              allowedArtifactTypes.map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))
+            ) : (
+              <option value="zip">zip</option>
+            )}
+          </select>
+        </div>
+
+        <div style={{ display: 'grid', gap: 6 }}>
+          <label style={{ fontWeight: 600 }}>Artifact</label>
+          {artifactType === 'url' ? (
+            <input
+              type="url"
+              placeholder="https://..."
+              value={artifactUrl}
+              onChange={(event) => setArtifactUrl(event.target.value)}
+              required
+              style={{
+                padding: '10px 12px',
+                border: '1px solid #d1d5db',
+                borderRadius: 8,
+                fontSize: 14,
+              }}
+            />
+          ) : (
+            <input
+              key={artifactType}
+              type="file"
+              accept={ACCEPT_BY_TYPE[artifactType] ?? ''}
+              onChange={(event) => setArtifactFile(event.target.files?.[0] ?? null)}
+              required
+              style={{
+                padding: '10px 12px',
+                border: '1px solid #d1d5db',
+                borderRadius: 8,
+                fontSize: 14,
+                backgroundColor: '#fff',
+              }}
+            />
+          )}
+        </div>
+
+        <div>
+          <button
+            type="submit"
+            style={{
+              padding: '10px 14px',
+              borderRadius: 8,
+              border: 'none',
+              backgroundColor: '#111827',
+              color: '#fff',
+              cursor: 'pointer',
+              fontWeight: 600,
+            }}
+          >
+            submit
+          </button>
+        </div>
       </form>
 
-      {message ? <p>{message}</p> : null}
+      {message ? <p style={{ marginTop: 12 }}>{message}</p> : null}
     </section>
   )
 }


### PR DESCRIPTION
• 1. 데이터 구조 정리

  - 기존 teams, hackathons는 읽기 전용 유지
  - 신규 리더보드 전용 저장소 추가: leaderboard_submissions
  - 신규 레코드 필드:
      - submissionId
      - hackathonSlug
      - teamId (teams.teamCode 참조)
      - submittedAt
      - totalScore

  2. Submit 로직 변경

  - 기존 submissions 저장은 그대로 유지
  - 제출 성공 시 leaderboard_submissions에도 함께 저장
  - totalScore는 제출 시 계산:
      - 해커톤 eval.scoreDisplay.breakdown 있으면 가중치 기반 계산
      - 없으면 해시 기반 fallback 점수
  - 팀 미선택 제출 방어 추가

  수정 파일:

  - src/features/Submit.tsx

  3. Leaderboard 로직 변경

  - 대상: 현재 해커톤 참여팀만 (team.hackathonSlug === 현재 slug)
  - 전체 참여팀을 항상 표시
  - 팀별 제출 집계:
      - 제출 없음: 미제출, score/rank 없음
      - 제출 있음: 최고 제출(max totalScore) 반영
      - 동점: submittedAt 빠른 제출 우선
  - 순위는 제출팀에만 부여, 미제출팀은 하단 정렬
  - 표시 컬럼 확장: Submissions, Best Submitted At

  수정 파일:

  - src/features/Leaderboard.tsx

  4. UI(디자인) 정리

  - Leaderboard: 행/열 구분선, 패딩 확대, 줄무늬 행, 가로 스크롤 대응
  - Submit: 가이드/폼 카드 분리, 간격/입력 스타일 정리, 버튼 스타일 개선
  - 로직 변경 없이 시각 개선만 수행