### PR TITLE
feat: 관심 해커톤 설정 기능 구현

### DIFF
--- a/src/components/HackathonCard.tsx
+++ b/src/components/HackathonCard.tsx
@@ -5,6 +5,8 @@ type HackathonCardProps = {
   thumbnailUrl: string
   deadline: string
   onClick?: () => void
+  isInterested?: boolean
+  onToggleInterest?: () => void
 }
 
 function formatDeadline(isoDate: string): string {
@@ -20,6 +22,8 @@ export default function HackathonCard({
   thumbnailUrl,
   deadline,
   onClick,
+  isInterested = false,
+  onToggleInterest,
 }: HackathonCardProps) {
 
   return (
@@ -30,8 +34,42 @@ export default function HackathonCard({
         padding: 20,
         margin: 10,
         cursor: onClick ? 'pointer' : 'default',
+        position: 'relative',
       }}
     >
+      {onToggleInterest ? (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation()
+            onToggleInterest()
+          }}
+          aria-label={isInterested ? '관심 해제' : '관심 등록'}
+          title={isInterested ? '관심 해제' : '관심 등록'}
+          style={{
+            position: 'absolute',
+            top: 10,
+            right: 10,
+            height: 32,
+            padding: '0 12px',
+            borderRadius: 9999,
+            border: `1px solid ${isInterested ? '#fda4af' : '#d1d5db'}`,
+            backgroundColor: isInterested ? '#fff1f2' : '#ffffff',
+            color: isInterested ? '#be123c' : '#374151',
+            cursor: 'pointer',
+            fontSize: 12,
+            fontWeight: 700,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          <span aria-hidden="true" style={{ fontSize: 13 }}>
+            {isInterested ? '♥' : '♡'}
+          </span>
+          <span>{isInterested ? '관심 있는 해커톤' : '관심 등록'}</span>
+        </button>
+      ) : null}
       <img
         src={thumbnailUrl}
         alt={title}

--- a/src/pages/HackathonDetail.tsx
+++ b/src/pages/HackathonDetail.tsx
@@ -9,6 +9,8 @@ import Submit from '../features/Submit'
 import Leaderboard from '../features/Leaderboard'
 import type { Hackathon } from '../types/hackathon'
 import { useLog } from '../contexts/LogContext'
+import { useUser } from '../contexts/UserContext'
+import { isHackathonInterested, toggleHackathonInterest } from '../utils/interestStorage'
 
 const HACKATHONS_STORAGE_KEY = 'hackathons'
 type SectionKey =
@@ -42,8 +44,10 @@ export default function HackathonDetail() {
   const { slug } = useParams()
   const navigate = useNavigate()
   const { recordEvent } = useLog()
+  const { user } = useUser()
   const hasLoggedView = useRef(false)
   const [activeSection, setActiveSection] = useState<SectionKey>('overview')
+  const [isInterested, setIsInterested] = useState(false)
 
   const hackathon = useMemo(() => {
     const hackathons = getHackathonsFromStorage()
@@ -56,6 +60,15 @@ export default function HackathonDetail() {
       hasLoggedView.current = true
     }
   }, [hackathon, recordEvent])
+
+  useEffect(() => {
+    if (!user || !hackathon) {
+      setIsInterested(false)
+      return
+    }
+
+    setIsInterested(isHackathonInterested(user.id, hackathon.slug))
+  }, [hackathon, user])
 
   if (!slug || !hackathon) {
     return <div>해당 해커톤을 찾을 수 없습니다.</div>
@@ -93,7 +106,42 @@ export default function HackathonDetail() {
           ← 메인으로
         </button>
       </div>
-      <h1>{hackathon.title}</h1>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <h1 style={{ margin: 0 }}>{hackathon.title}</h1>
+        <button
+          type="button"
+          onClick={() => {
+            if (!user) {
+              alert('로그인 후 관심 등록할 수 있습니다.')
+              return
+            }
+
+            const next = toggleHackathonInterest(user.id, hackathon.slug)
+            setIsInterested(next)
+          }}
+          aria-label={isInterested ? '관심 해제' : '관심 등록'}
+          title={isInterested ? '관심 해제' : '관심 등록'}
+          style={{
+            height: 36,
+            padding: '0 14px',
+            borderRadius: 9999,
+            border: `1px solid ${isInterested ? '#fda4af' : '#d1d5db'}`,
+            backgroundColor: isInterested ? '#fff1f2' : '#ffffff',
+            color: isInterested ? '#be123c' : '#374151',
+            cursor: 'pointer',
+            fontSize: 13,
+            fontWeight: 700,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          <span aria-hidden="true" style={{ fontSize: 14 }}>
+            {isInterested ? '♥' : '♡'}
+          </span>
+          <span>{isInterested ? '관심 있는 해커톤' : '관심 등록'}</span>
+        </button>
+      </div>
       <img
         src={hackathon.thumbnailUrl}
         alt={hackathon.title}

--- a/src/pages/Hackathons.tsx
+++ b/src/pages/Hackathons.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import HackathonCard from '../components/HackathonCard'
 import type { Hackathon } from '../types/hackathon'
+import { useUser } from '../contexts/UserContext'
+import { isHackathonInterested, toggleHackathonInterest } from '../utils/interestStorage'
 
 const HACKATHONS_STORAGE_KEY = 'hackathons'
 
@@ -19,8 +21,10 @@ function getHackathonsFromStorage(): Hackathon[] {
 
 export default function Hackathons() {
   const navigate = useNavigate()
+  const { user } = useUser()
   const [statusFilter, setStatusFilter] = useState<string>('all')
   const [tagFilter, setTagFilter] = useState<string>('all')
+  const [, setInterestVersion] = useState(0)
   const hackathons = useMemo(() => getHackathonsFromStorage(), [])
   const statusOptions = useMemo(
     () => Array.from(new Set(hackathons.map((hackathon) => hackathon.status))),
@@ -125,6 +129,20 @@ export default function Hackathons() {
             thumbnailUrl={hackathon.thumbnailUrl}
             deadline={hackathon.period.submissionDeadlineAt}
             onClick={() => navigate(`/hackathons/${hackathon.slug}`)}
+            isInterested={
+              user
+                ? isHackathonInterested(user.id, hackathon.slug)
+                : false
+            }
+            onToggleInterest={() => {
+              if (!user) {
+                alert('로그인 후 관심 등록할 수 있습니다.')
+                return
+              }
+
+              toggleHackathonInterest(user.id, hackathon.slug)
+              setInterestVersion((prev) => prev + 1)
+            }}
           />
         ))
       )}

--- a/src/utils/interestStorage.ts
+++ b/src/utils/interestStorage.ts
@@ -1,0 +1,67 @@
+export type HackathonInterest = {
+  userId: string
+  hackathonId: string
+  interestedAt: string
+}
+
+const HACKATHON_INTERESTS_STORAGE_KEY = 'hackathon_interests'
+
+function loadAllInterests(): HackathonInterest[] {
+  const raw = localStorage.getItem(HACKATHON_INTERESTS_STORAGE_KEY)
+  if (!raw) return []
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+
+    return parsed.filter(
+      (item): item is HackathonInterest =>
+        item &&
+        typeof item.userId === 'string' &&
+        typeof item.hackathonId === 'string' &&
+        typeof item.interestedAt === 'string'
+    )
+  } catch {
+    return []
+  }
+}
+
+function saveAllInterests(interests: HackathonInterest[]) {
+  localStorage.setItem(HACKATHON_INTERESTS_STORAGE_KEY, JSON.stringify(interests))
+}
+
+export function getUserHackathonInterests(userId: string): HackathonInterest[] {
+  return loadAllInterests().filter((item) => item.userId === userId)
+}
+
+export function isHackathonInterested(userId: string, hackathonId: string): boolean {
+  return loadAllInterests().some(
+    (item) => item.userId === userId && item.hackathonId === hackathonId
+  )
+}
+
+export function toggleHackathonInterest(userId: string, hackathonId: string): boolean {
+  const current = loadAllInterests()
+  const exists = current.some(
+    (item) => item.userId === userId && item.hackathonId === hackathonId
+  )
+
+  if (exists) {
+    const next = current.filter(
+      (item) => !(item.userId === userId && item.hackathonId === hackathonId)
+    )
+    saveAllInterests(next)
+    return false
+  }
+
+  const next = [
+    ...current,
+    {
+      userId,
+      hackathonId,
+      interestedAt: new Date().toISOString(),
+    },
+  ]
+  saveAllInterests(next)
+  return true
+}


### PR DESCRIPTION
• 1. 추가된 기능

  - 해커톤 관심등록 기능 추가
  - 해커톤 목록 카드에서 관심 등록/해제 가능
  - 해커톤 상세 페이지에서 관심 등록/해제 가능
  - 목록/상세가 같은 관심 데이터 저장소를 공유

  2. 추가된/수정된 데이터

  - 추가된 데이터 저장 키: hackathon_interests (localStorage)
  - 데이터 구조:

  type HackathonInterest = {
    userId: string
    hackathonId: string
    interestedAt: string
  }

  - 저장 방식: 관심 누른 건만 행 존재, 해제 시 해당 행 삭제

  3. 수정한 파일

  - 신규: src/utils/interestStorage.ts
  - 수정: src/components/HackathonCard.tsx
  - 수정: src/pages/Hackathons.tsx
  - 수정: src/pages/HackathonDetail.tsx

  4. 값 접근 방법

  - 공용 유틸 함수 사용:
      - getUserHackathonInterests(userId) : 유저 관심 목록 조회
      - isHackathonInterested(userId, hackathonId) : 관심 여부 확인
      - toggleHackathonInterest(userId, hackathonId) : 등록/해제 토글
  - 직접 접근 시:
      - localStorage.getItem('hackathon_interests') 후 JSON 파싱