### PR TITLE
style : 해커톤페이지 목록 및 팀 섹션 디자인 변경

### DIFF
--- a/src/features/Teams.tsx
+++ b/src/features/Teams.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { AlertTriangle, CheckCircle2, Info, Users } from 'lucide-react'
 import { useTeams, useUpdateTeam, useUserInvites, useRespondToInvite } from '../hooks/useTeams'
 import { useUser } from '../contexts/UserContext'
+import { Button } from '@/components/ui/button'
 
 type TeamsProps = {
   hackathonSlug: string
@@ -15,8 +17,9 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
   const { data: userInvites } = useUserInvites(user?.id || '')
   const respondMutation = useRespondToInvite()
   const updateMutation = useUpdateTeam()
-  
+
   const [noticeOpen, setNoticeOpen] = useState(false)
+  const [noticeConfirmed, setNoticeConfirmed] = useState(false)
   const [applyModalOpen, setApplyModalOpen] = useState(false)
 
   // 내가 만든 팀 중 이 해커톤에 참여하지 않은 팀들 필터링
@@ -25,6 +28,7 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
   )
 
   function handleOpenCreateNotice() {
+    setNoticeConfirmed(false)
     setNoticeOpen(true)
   }
 
@@ -38,39 +42,40 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
   }
 
   function handleApplyWithTeam(teamCode: string) {
-    if (window.confirm('이 팀으로 해커톤 참여 신청을 하시겠습니까?')) {
-      updateMutation.mutate({
+    updateMutation.mutate(
+      {
         teamCode,
         updates: { hackathonSlug }
-      }, {
+      },
+      {
         onSuccess: () => {
           alert('참여 신청이 완료되었습니다!')
           setApplyModalOpen(false)
         }
-      })
-    }
+      }
+    )
   }
 
   const handleRespond = (inviteId: string, status: 'ACCEPTED' | 'REJECTED') => {
     if (window.confirm(`초대를 ${status === 'ACCEPTED' ? '수락' : '거절'}하시겠습니까? 한번 선택하면 변경할 수 없습니다.`)) {
-      respondMutation.mutate({ inviteId, status });
+      respondMutation.mutate({ inviteId, status })
     }
-  };
+  }
 
   return (
     <section>
       <h2>Teams</h2>
 
-      <div style={{ display: 'flex', gap: 10, marginBottom: 20 }}>
-        <button 
-          type="button" 
+      <div style={{ display: 'flex', gap: 10, marginBottom: 20, justifyContent: 'center', flexWrap: 'wrap' }}>
+        <button
+          type="button"
           onClick={handleOpenCreateNotice}
-          style={{ 
-            backgroundColor: '#ebf8ff', 
-            color: '#2b6cb0', 
-            border: '1px solid #bee3f8', 
-            padding: '8px 16px', 
-            borderRadius: '4px', 
+          style={{
+            backgroundColor: '#ebf8ff',
+            color: '#2b6cb0',
+            border: '1px solid #bee3f8',
+            padding: '8px 16px',
+            borderRadius: '4px',
             cursor: 'pointer',
             fontWeight: 'bold'
           }}
@@ -78,10 +83,19 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
           새 팀 생성하기
         </button>
         {user && myAvailableTeams && myAvailableTeams.length > 0 && (
-          <button 
-            type="button" 
+          <button
+            type="button"
             onClick={() => setApplyModalOpen(true)}
-            style={{ backgroundColor: '#10b981', color: 'white', border: 'none', padding: '8px 16px', borderRadius: '4px', cursor: 'pointer' }}
+            style={{
+              backgroundImage: 'linear-gradient(90deg, #3B82F6, #0EA5E9)',
+              color: 'white',
+              border: 'none',
+              padding: '8px 16px',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontWeight: 'bold',
+              boxShadow: '0 8px 20px rgba(14, 165, 233, 0.25)'
+            }}
           >
             내 팀으로 신청하기 ({myAvailableTeams.length})
           </button>
@@ -95,12 +109,15 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
       ) : (
         teams.map((team) => {
           // 해당 팀에서 온 초대 중 PENDING인 것을 먼저 찾고, 없으면 가장 최근의 것을 찾음
-          const teamInvites = userInvites?.filter(inv => inv.teamId === team.teamCode) || [];
-          const invite = teamInvites.find(inv => inv.status === 'PENDING') || 
-                         (teamInvites.length > 0 ? [...teamInvites].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0] : null);
-          
-          const isLeader = team.leaderId === user?.id;
-          
+          const teamInvites = userInvites?.filter((inv) => inv.teamId === team.teamCode) || []
+          const invite =
+            teamInvites.find((inv) => inv.status === 'PENDING') ||
+            (teamInvites.length > 0
+              ? [...teamInvites].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0]
+              : null)
+
+          const isLeader = team.leaderId === user?.id
+
           return (
             <article
               key={team.teamCode}
@@ -110,46 +127,73 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
                 <div>
                   <h3>{team.name}</h3>
                   <p>{team.intro}</p>
-                  <p>Members: {team.memberCount}/{team.maxMembers}명</p>
+                  <p>
+                    Members: {team.memberCount}/{team.maxMembers}명
+                  </p>
                   <p>Status: {team.isOpen ? '모집중' : '모집마감'}</p>
                   <p>Looking For: {team.lookingFor.join(', ') || '-'}</p>
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                   {isLeader && (
-                    <button 
+                    <button
                       onClick={() => navigate(`/team/${team.teamCode}/manage`)}
-                      style={{ backgroundColor: '#3b82f6', color: 'white', border: 'none', padding: '8px 12px', borderRadius: 4, cursor: 'pointer' }}
+                      style={{
+                        backgroundColor: '#3b82f6',
+                        color: 'white',
+                        border: 'none',
+                        padding: '8px 12px',
+                        borderRadius: 4,
+                        cursor: 'pointer'
+                      }}
                     >
                       관리
                     </button>
                   )}
-                  
+
                   {invite && (
                     <div style={{ border: '1px solid #eee', padding: 8, borderRadius: 4, backgroundColor: '#f9fafb' }}>
                       <p style={{ margin: '0 0 8px 0', fontSize: '0.85rem', fontWeight: 'bold' }}>팀 초대</p>
                       {invite.status === 'PENDING' ? (
                         <div style={{ display: 'flex', gap: 4 }}>
-                          <button 
+                          <button
                             onClick={() => handleRespond(invite.id, 'ACCEPTED')}
                             disabled={respondMutation.isPending}
-                            style={{ backgroundColor: '#10b981', color: 'white', border: 'none', padding: '4px 8px', borderRadius: 4, fontSize: '0.8rem', cursor: 'pointer' }}
+                            style={{
+                              backgroundColor: '#10b981',
+                              color: 'white',
+                              border: 'none',
+                              padding: '4px 8px',
+                              borderRadius: 4,
+                              fontSize: '0.8rem',
+                              cursor: 'pointer'
+                            }}
                           >
                             수락
                           </button>
-                          <button 
+                          <button
                             onClick={() => handleRespond(invite.id, 'REJECTED')}
                             disabled={respondMutation.isPending}
-                            style={{ backgroundColor: '#ef4444', color: 'white', border: 'none', padding: '4px 8px', borderRadius: 4, fontSize: '0.8rem', cursor: 'pointer' }}
+                            style={{
+                              backgroundColor: '#ef4444',
+                              color: 'white',
+                              border: 'none',
+                              padding: '4px 8px',
+                              borderRadius: 4,
+                              fontSize: '0.8rem',
+                              cursor: 'pointer'
+                            }}
                           >
                             거절
                           </button>
                         </div>
                       ) : (
-                        <span style={{ 
-                          fontSize: '0.85rem', 
-                          fontWeight: 'bold',
-                          color: invite.status === 'ACCEPTED' ? '#10b981' : '#ef4444' 
-                        }}>
+                        <span
+                          style={{
+                            fontSize: '0.85rem',
+                            fontWeight: 'bold',
+                            color: invite.status === 'ACCEPTED' ? '#10b981' : '#ef4444'
+                          }}
+                        >
                           {invite.status === 'ACCEPTED' ? '초대 수락됨' : '초대 거절됨'}
                         </span>
                       )}
@@ -159,7 +203,7 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
               </div>
               <p style={{ marginTop: 10, fontSize: '0.9rem', color: '#666' }}>Contact: {team.contact.url}</p>
             </article>
-          );
+          )
         })
       )}
 
@@ -168,55 +212,78 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
         <div
           role="dialog"
           aria-modal="true"
+          aria-labelledby="team-create-notice-title"
           style={{
             position: 'fixed',
             inset: 0,
-            backgroundColor: 'rgba(0, 0, 0, 0.45)',
+            backgroundColor: 'rgba(15, 23, 42, 0.5)',
             display: 'grid',
             placeItems: 'center',
             padding: 16,
             zIndex: 1000,
+            backdropFilter: 'blur(6px)'
           }}
         >
-          <div style={{ backgroundColor: '#fff', color: '#111', maxWidth: 560, padding: 16, borderRadius: 8 }}>
-            <h3>Team Participation Notice</h3>
-            <p>팀 생성/참여 전 아래 규칙을 확인하세요.</p>
-            <ul>
-              <li>한 해커톤에서 활동 정책을 준수해야 합니다.</li>
-              <li>팀원 간 연락과 역할 분담은 팀 내부에서 명확히 합의해야 합니다.</li>
-              <li>운영 정책 위반 시 팀 참여가 제한될 수 있습니다.</li>
-            </ul>
-            <button 
-              type="button" 
-              onClick={handleConfirmNotice}
-              style={{ 
-                backgroundColor: '#3b82f6', 
-                color: 'white', 
-                border: 'none', 
-                padding: '8px 16px', 
-                borderRadius: '4px', 
-                cursor: 'pointer',
-                fontWeight: 'bold'
-              }}
-            >
-              Confirm
-            </button>
-            <button 
-              type="button" 
-              onClick={handleCloseNotice} 
-              style={{ 
-                marginLeft: 8, 
-                backgroundColor: '#f3f4f6', 
-                color: '#4b5563', 
-                border: '1px solid #d1d5db', 
-                padding: '8px 16px', 
-                borderRadius: '4px', 
-                cursor: 'pointer',
-                fontWeight: 'bold'
-              }}
-            >
-              Cancel
-            </button>
+          <div className="w-full max-w-2xl rounded-3xl border border-blue-100/80 bg-gradient-to-b from-white via-sky-50/50 to-white p-6 shadow-2xl sm:p-8">
+            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-[#3B82F6] to-[#0EA5E9] text-white shadow-lg">
+              <Info className="h-7 w-7" />
+            </div>
+            <h3 id="team-create-notice-title" className="text-center text-2xl font-extrabold tracking-tight text-slate-900">
+              팀 생성 전 확인사항
+            </h3>
+            <p className="mx-auto mt-2 max-w-xl text-center text-sm font-medium text-slate-600 sm:text-base">
+              원활한 협업을 위해 아래 항목을 먼저 확인해주세요.
+            </p>
+
+            <div className="mt-6 space-y-3">
+              <div className="rounded-2xl border border-sky-100 bg-white/90 p-4 shadow-sm">
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-sky-500" />
+                  <p className="text-sm font-semibold text-slate-700">한 해커톤 내 운영 정책 및 제출 가이드를 준수해야 합니다.</p>
+                </div>
+              </div>
+              <div className="rounded-2xl border border-sky-100 bg-white/90 p-4 shadow-sm">
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-sky-500" />
+                  <p className="text-sm font-semibold text-slate-700">팀 내 역할과 일정은 사전에 합의하고, 변경 시 즉시 공유해주세요.</p>
+                </div>
+              </div>
+              <div className="rounded-2xl border border-amber-100 bg-amber-50/70 p-4 shadow-sm">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+                  <p className="text-sm font-semibold text-slate-700">운영 정책 위반 시 팀 활동 또는 해커톤 참여가 제한될 수 있습니다.</p>
+                </div>
+              </div>
+            </div>
+
+            <label className="mt-5 flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-700">
+              <input
+                type="checkbox"
+                checked={noticeConfirmed}
+                onChange={(event) => setNoticeConfirmed(event.target.checked)}
+                className="h-4 w-4 accent-[#3B82F6]"
+              />
+              안내사항을 모두 확인했습니다.
+            </label>
+
+            <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+              <Button
+                type="button"
+                onClick={handleCloseNotice}
+                variant="outline"
+                className="min-w-32 rounded-xl border-slate-200 bg-white font-semibold text-slate-700 hover:bg-slate-50"
+              >
+                취소
+              </Button>
+              <Button
+                type="button"
+                onClick={handleConfirmNotice}
+                disabled={!noticeConfirmed}
+                className="min-w-40 rounded-xl bg-gradient-to-r from-[#3B82F6] to-[#0EA5E9] font-semibold text-white shadow-md hover:opacity-95"
+              >
+                확인하고 생성하기
+              </Button>
+            </div>
           </div>
         </div>
       ) : null}
@@ -226,48 +293,63 @@ export default function Teams({ hackathonSlug }: TeamsProps) {
         <div
           role="dialog"
           aria-modal="true"
+          aria-labelledby="team-apply-modal-title"
           style={{
             position: 'fixed',
             inset: 0,
-            backgroundColor: 'rgba(0, 0, 0, 0.45)',
+            backgroundColor: 'rgba(15, 23, 42, 0.5)',
             display: 'grid',
             placeItems: 'center',
             padding: 16,
             zIndex: 1000,
+            backdropFilter: 'blur(6px)'
           }}
         >
-          <div style={{ backgroundColor: '#fff', color: '#111', width: '100%', maxWidth: 500, padding: 20, borderRadius: 8 }}>
-            <h3>참여할 팀 선택</h3>
-            <p>이 해커톤에 참여 신청할 팀을 선택해주세요.</p>
-            <div style={{ maxHeight: '300px', overflowY: 'auto', margin: '20px 0' }}>
+          <div className="w-full max-w-2xl rounded-3xl border border-blue-100/80 bg-gradient-to-b from-white via-sky-50/50 to-white p-6 shadow-2xl sm:p-8">
+            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-[#3B82F6] to-[#0EA5E9] text-white shadow-lg">
+              <Users className="h-7 w-7" />
+            </div>
+            <h3 id="team-apply-modal-title" className="text-center text-2xl font-extrabold tracking-tight text-slate-900">
+              참여할 팀 선택
+            </h3>
+            <p className="mx-auto mt-2 max-w-xl text-center text-sm font-medium text-slate-600 sm:text-base">
+              이 해커톤에 참여 신청할 내 팀을 선택해주세요.
+            </p>
+
+            <div className="mt-6 max-h-[300px] space-y-3 overflow-y-auto pr-1">
               {myAvailableTeams?.map((team) => (
-                <div 
-                  key={team.teamCode} 
-                  style={{ border: '1px solid #eee', padding: 12, marginBottom: 10, borderRadius: 6, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+                <div
+                  key={team.teamCode}
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-sky-100 bg-white/90 p-4 shadow-sm"
                 >
                   <div>
-                    <div style={{ fontWeight: 'bold' }}>{team.name}</div>
-                    <div style={{ fontSize: '0.8rem', color: '#666' }}>
+                    <div className="text-base font-bold text-slate-900">{team.name}</div>
+                    <div className="text-xs font-medium text-slate-500">
                       {team.hackathonSlug ? `현재 참여: ${team.hackathonSlug}` : '해커톤 미지정'}
                     </div>
                   </div>
-                  <button 
+                  <Button
+                    type="button"
                     onClick={() => handleApplyWithTeam(team.teamCode)}
                     disabled={updateMutation.isPending}
-                    style={{ padding: '6px 12px', fontSize: '0.9rem' }}
+                    className="rounded-xl bg-gradient-to-r from-[#3B82F6] to-[#0EA5E9] font-semibold text-white shadow-md hover:opacity-95"
                   >
-                    신청
-                  </button>
+                    {updateMutation.isPending ? '신청 중...' : '이 팀으로 신청'}
+                  </Button>
                 </div>
               ))}
             </div>
-            <button 
-              type="button" 
-              onClick={() => setApplyModalOpen(false)} 
-              style={{ width: '100%', backgroundColor: '#eee', color: '#333' }}
-            >
-              닫기
-            </button>
+
+            <div className="mt-6 flex justify-center">
+              <Button
+                type="button"
+                onClick={() => setApplyModalOpen(false)}
+                variant="outline"
+                className="min-w-40 rounded-xl border-slate-200 bg-white font-semibold text-slate-700 hover:bg-slate-50"
+              >
+                닫기
+              </Button>
+            </div>
           </div>
         </div>
       ) : null}

--- a/src/pages/Hackathons.tsx
+++ b/src/pages/Hackathons.tsx
@@ -116,7 +116,7 @@ export default function Hackathons() {
               <Button
                 variant={tagFilter === 'all' ? 'secondary' : 'outline'}
                 onClick={() => setTagFilter('all')}
-                className={tagFilter === 'all' ? 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200 border-0' : 'hover:border-emerald-500 hover:text-emerald-500'}
+                className={tagFilter === 'all' ? 'bg-gradient-to-r from-[#3B82F6] to-[#0EA5E9] text-white border-0 shadow-sm hover:opacity-95 transition-all' : 'border-sky-200 bg-white text-slate-600 hover:border-sky-300 hover:bg-sky-50 hover:text-[#2563EB] transition-colors'}
                 size="sm"
               >
                 태그 전체
@@ -126,7 +126,7 @@ export default function Hackathons() {
                   key={tag}
                   variant={tagFilter === tag ? 'secondary' : 'outline'}
                   onClick={() => setTagFilter(tag)}
-                  className={tagFilter === tag ? 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200 border-0' : 'hover:border-emerald-500 hover:text-emerald-500'}
+                  className={tagFilter === tag ? 'bg-gradient-to-r from-[#3B82F6] to-[#0EA5E9] text-white border-0 shadow-sm hover:opacity-95 transition-all' : 'border-sky-200 bg-white text-slate-600 hover:border-sky-300 hover:bg-sky-50 hover:text-[#2563EB] transition-colors'}
                   size="sm"
                 >
                   {tag}
@@ -228,13 +228,13 @@ export default function Hackathons() {
                       <Badge 
                         key={tag} 
                         variant="secondary" 
-                        className="bg-blue-50 text-blue-600 border-0 hover:bg-blue-100 transition-colors"
+                        className="border border-sky-100 bg-sky-50 text-sky-700 hover:border-sky-200 hover:bg-sky-100 transition-colors font-medium"
                       >
                         #{tag}
                       </Badge>
                     ))}
                     {hackathon.tags.length > 3 && (
-                      <Badge variant="outline" className="text-gray-400 border-gray-100">
+                      <Badge variant="outline" className="bg-white text-slate-500 border-slate-200">
                         +{hackathon.tags.length - 3}
                       </Badge>
                     )}


### PR DESCRIPTION
 - 해커톤 상세 Teams 섹션 UX/디자인 개선
  - 해커톤 목록 태그 UI를 메인 컨셉 톤으로 통일

  주요 변경사항:

  1. 팀 생성 안내 모달 개선

  - 새 팀 생성하기 클릭 시 중앙 모달 + 배경 blur/dim 적용
  - 블루-시안 메인 톤 카드형 디자인으로 변경
  - 안내 체크박스 확인 시에만 확인하고 생성하기 활성화
  - 하단 버튼 가운데 정렬

  2. 내 팀 신청 UX 개선

  - 내 팀으로 신청하기 버튼을 메인 그라디언트로 변경
  - 신청 모달도 동일한 디자인 시스템(중앙 카드/blur 배경/라운드/그라디언트) 적용
  - 모달 내 팀 카드형 리스트 + 액션 버튼 스타일 통일

  3. 해커톤 목록 태그 스타일 정리

  - 태그 필터 버튼 활성/비활성 스타일을 메인 컨셉에 맞게 조정
  - 카드 내 태그 칩을 소프트 블루 톤으로 완화
  - +N 배지는 중립 컬러로 조정해 과한 강조 제거

  수정 파일:

  - src/features/Teams.tsx
  - src/pages/Hackathons.tsx